### PR TITLE
change c++ standard from C++2a to C++17

### DIFF
--- a/cpp-template-utils.pro
+++ b/cpp-template-utils.pro
@@ -7,7 +7,7 @@ win*{
 CONFIG += staticlib
 CONFIG -= qt
 
-CONFIG += strict_c++ c++2a
+CONFIG += strict_c++ c++17
 
 *g++*:QMAKE_CXXFLAGS += -fconcepts
 *msvc*:QMAKE_CXXFLAGS += /Zc:char8_t

--- a/tests/test-app/cpp-template-utils-test-app.pro
+++ b/tests/test-app/cpp-template-utils-test-app.pro
@@ -1,4 +1,4 @@
-CONFIG += strict_c++ c++2a
+CONFIG += strict_c++ c++17
 CONFIG -= qt
 
 TEMPLATE = app
@@ -21,7 +21,7 @@ win*{
 
 linux*|mac*{
 	QMAKE_CXXFLAGS_WARN_ON = -Wall -Wno-c++11-extensions -Wno-local-type-template-args -Wno-deprecated-register
-	QMAKE_CXXFLAGS += -std=c++2a
+	QMAKE_CXXFLAGS += -std=c++17
 
 	Release:DEFINES += NDEBUG=1
 	Debug:DEFINES += _DEBUG


### PR DESCRIPTION
under ubuntu the project fails to compile because  some code fragments are not compatible with  c++2a.